### PR TITLE
Remove timing and statistics output to align with Unix command philosophy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashSet, path::PathBuf};
 use std::thread;
-use std::time::Instant;
 use glob::Pattern;
 use clap::Parser;
 use colored::*;
@@ -64,9 +63,6 @@ struct WorkUnit {
 }
 
 fn main() {
-    // Start timing
-    let start_time = Instant::now();
-    
     let args = Args::parse();
     let pattern = Arc::new(create_pattern_matcher(&args.pattern));
     let max_depth = args.max_depth;
@@ -196,10 +192,7 @@ fn main() {
     drop(dir_tx);
     drop(result_tx);
 
-    // Print results as they come in
-    let mut count = 0;
     while let Ok(path) = result_rx.recv() {
-        count += 1;
         println!("{}", format!("{}", path.display()).green());
     }
 
@@ -208,11 +201,4 @@ fn main() {
         handle.join().unwrap();
     }
     distributor_handle.join().unwrap();
-
-    // Calculate and print elapsed time
-    let elapsed = start_time.elapsed();
-    
-    println!("\n{}", format!("Total matches found: {}", count).blue());
-    println!("{}", format!("Used {} worker threads", thread_count).yellow());
-    println!("{}", format!("Total time: {:.2?}", elapsed).cyan());
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -106,14 +106,10 @@ fn test_file_finder_integration() -> Result<(), Box<dyn std::error::Error>> {
             let reader = BufReader::new(stdout);
             for line in reader.lines() {
                 let line = line?;
-                if !line.contains("Total matches found:") && 
-                   !line.contains("Used") && 
-                   !line.contains("Total time:") {
-                    if let Some(file_name) = Path::new(&line.trim())
-                        .file_name()
-                        .and_then(|n| n.to_str()) {
-                        found_files.insert(String::from(file_name));
-                    }
+                if let Some(file_name) = Path::new(&line.trim())
+                    .file_name()
+                    .and_then(|n| n.to_str()) {
+                    found_files.insert(String::from(file_name));
                 }
             }
         }


### PR DESCRIPTION
## Summary
This change removes timing statistics and other auxiliary output to make the tool 
more composable and focused on its core functionality, following the Unix philosophy 
of "do one thing well" and producing output that's suitable as input for other programs.

## Changes
- Remove timing measurement and elapsed time output
- Remove match count tracking and display
- Remove thread count information display
- Simplify integration tests by removing checks for auxiliary output

## Motivation
The Unix philosophy emphasizes creating tools that:
1. Focus on a single task
2. Produce output that can be easily piped to other programs
3. Work with text streams as a universal interface

The removed statistics output made our tool less composable with other Unix tools
since it mixed the core output (file paths) with auxiliary information. Now the 
program outputs only file paths, making it easier to pipe the results into other 
commands like `xargs`, `grep`, or `sort`.

## Testing
- Existing integration tests have been updated to reflect the simplified output
- Core functionality remains unchanged
- Manual testing performed with various pipe operations to verify composability

## Example Usage
Before:
```bash
$ ./finder "*.rs"
/path/to/file1.rs
/path/to/file2.rs

Total matches found: 2
Used 4 worker threads
Total time: 1.23s
```

After:
```bash
$ ./finder "*.rs"
/path/to/file1.rs
/path/to/file2.rs
```

Now the output can be easily used in pipelines like:
```bash
$ ./finder "*.rs" | xargs cat | grep "TODO"
```

