### PR TITLE
Add Boyer-Moore-Horspool search and print0 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
   -H, --cmd-follow             Follow symbolic links on command line only
   -L, --follow-all             Follow all symbolic links
   -t, --type <TYPE_FILTER>     Filter the results by type. Possible values: f|file, d|dir, l|symlink, or any [default: any]
+  --print0                     Print each matching path followed by a null character ('\0') instead of a newline
   -h, --help                   Print help
   -V, --version                Print version
 ```
@@ -113,6 +114,18 @@ Use `-t` (or `--type`) to filter results by file type:
   rfind -t any "*test*"
   ```
   Shows both files, directories, and symlinks that have "test" in their name.
+
+### Using `--print0` with `xargs -0`
+
+When `--print0` is specified, rfind outputs each matching path followed by a null character (`'\0'`) instead of a newline. This is especially useful when filenames may contain spaces, newlines, or other special characters, allowing you to safely pass them to tools like `xargs -0`:
+
+```bash
+rfind --print0 "*.txt" -d . | xargs -0 grep "some_pattern"
+```
+
+In this example:
+* `--print0` ensures that files are delimited by a null character.
+* `xargs -0` then safely processes the null-delimited filenames, preventing unwanted splitting.
 
 ## 🔧 Installation
 


### PR DESCRIPTION
# Add Boyer-Moore-Horspool search and print0 option

## Changes
- Added `--print0` option to support null-terminated output, making it easier to pipe results to tools like `xargs -0`
- Improved pattern matching performance by replacing naive substring search with Boyer-Moore-Horspool algorithm via `memchr::memmem::FinderBuilder`
- Fixed path normalization to prepend "/" for better compatibility with command line tools
- Reordered struct definitions to improve code organization

## Performance Impact
The new pattern matching implementation should be significantly faster for substring searches due to:
- Using Boyer-Moore-Horspool algorithm instead of naive contains()
- Avoiding redundant string allocations in the hot path
- Leveraging SIMD optimizations when available through memchr

## Example Usage
```bash
# Search for text files and grep their contents
rfind --print0 "*.txt" -d . | xargs -0 grep "pattern"

# Handle filenames with spaces safely
rfind --print0 "*.pdf" | xargs -0 mv -t /destination/
```

## Documentation
- Added new `--print0` option to help text and README
- Added usage examples for `--print0` with xargs
- Updated internal code comments

