### PR TITLE
Add Size-Based Filtering Option to `rfind`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Options:
       --mtime <MTIME>          Filter by modification time (format: [+-]N[smhd]) Examples: +1d (more than 1 day), -2m (less than 2 minutes), 3d (exactly 3 days), +1h (more than 1 hour), -45s (less than 45 seconds)
       --atime <ATIME>          Filter by access time (format: [+-]N[smhd])
       --ctime <CTIME>          Filter by change time (format: [+-]N[smhd])
+      --size <SIZE>            Filter by file size (format: [+-]N[ckMG]) Examples: +1M (more than 1MB), -500k (less than 500KB), 1G (exactly 1GB)
   -h, --help                   Print help
   -V, --version                Print version
 ```

--- a/README.md
+++ b/README.md
@@ -226,13 +226,13 @@ Use `--size` to filter files by size using `[+-]N[ckMG]` format:
 - `+` for larger, `-` for smaller, no prefix for exact match
 
 ```bash
-# Find files larger than 1GB
+# Find files larger than 1GiB
 rfind "*" --size +1G
 
-# Find small configs (<10KB)
+# Find small configs (<10KiB)
 rfind "*.conf" --size -10k
 
-# Large logs (>100MB) not accessed in a week
+# Large logs (>100MiB) not accessed in a week
 rfind "*.log" --size +100M --atime +7d
 
 # Find and compress large old logs

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
       --mtime <MTIME>          Filter by modification time (format: [+-]N[smhd]) Examples: +1d (more than 1 day), -2m (less than 2 minutes), 3d (exactly 3 days), +1h (more than 1 hour), -45s (less than 45 seconds)
       --atime <ATIME>          Filter by access time (format: [+-]N[smhd])
       --ctime <CTIME>          Filter by change time (format: [+-]N[smhd])
-      --size <SIZE>            Filter by file size (format: [+-]N[ckMG]) Examples: +1M (more than 1MB), -500k (less than 500KB), 1G (exactly 1GB)
+      --size <SIZE>            Filter by file size (format: [+-]N[ckMG]) Examples: +1M (more than 1MiB), -500k (less than 500KiB), 1G (approximately 1GiB)
   -h, --help                   Print help
   -V, --version                Print version
 ```

--- a/README.md
+++ b/README.md
@@ -218,6 +218,29 @@ You can combine multiple time filters to create more specific searches:
   rfind "*.conf" --ctime -30m --mtime +7d
   ```
 
+### 🚛 Size-Based Filtering 
+
+Use `--size` to filter files by size using `[+-]N[ckMG]` format:
+- `c` (bytes), `k` (KB), `M` (MB), `G` (GB)
+- `+` for larger, `-` for smaller, no prefix for exact match
+
+```bash
+# Find files larger than 1GB
+rfind "*" --size +1G
+
+# Find small configs (<10KB)
+rfind "*.conf" --size -10k
+
+# Large logs (>100MB) not accessed in a week
+rfind "*.log" --size +100M --atime +7d
+
+# Find and compress large old logs
+rfind "*.log" --size +100M --mtime +7d --print0 | xargs -0 gzip -9
+
+# Calculate the total size of old large files
+rfind "*" --size +1G --mtime +30d --print0 | xargs -0 du -ch
+```
+
 ## 💡 Additional Suggestions
 
 - **Avoiding hidden files or directories**: Currently, `rfind` doesn’t provide a built-in flag to ignore `.*` entries. For now, you can combine `rfind` with standard shell utilities like `grep` or `sed` to filter results if you need to exclude hidden files:

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,7 +141,7 @@ struct SizeFilter {
 
 impl SizeFilter {
     /// Parse a size filter string in the format: [+-]N[ckmG]
-    /// Examples: "+1M" (more than 1 MB), "-500k" (less than 500 KB), "1G" (about 1 GB)
+    /// Examples: "+1M" (more than 1 MiB), "-500k" (less than 500 KiB), "1G" (about 1 GiB)
     fn parse(s: &str) -> Result<Self, String> {
         let (comparison, rest) = match s.chars().next() {
             Some('+') => (SizeComparison::Greater, &s[1..]),
@@ -321,7 +321,7 @@ struct Args {
     ctime: Option<String>,
 
     /// Filter by file size (format: [+-]N[ckMG])
-    /// Examples: +1M (more than 1MB), -500k (less than 500KB), 1G (exactly 1GB)
+    /// Examples: +1M (more than 1MiB), -500k (less than 500KiB), 1G (approximately 1GiB)
     #[arg(long = "size", allow_hyphen_values = true)]
     size: Option<String>,
 }


### PR DESCRIPTION
This pull request introduces a new feature for `rfind` to filter files based on their sizes. Key changes include:

- **New Option `--size`**: Allows filtering files by their size using the format `[+-]N[ckMG]`.
  - `c` for bytes
  - `k` for kebibytes
  - `M` for mebibytes
  - `G` for gibibytes
  - `+` for files larger than the specified size
  - `-` for files smaller than the specified size
  - No prefix for approximate size match
- **Examples**:
  - `--size +1G`: Find files larger than 1GiB
  - `--size -500k`: Find files smaller than 500KiB
  - `--size 1M`: Find files approximately 1MiB in size
- **Implementation**:
  - Added `SizeComparison` and `SizeUnit` enums for size comparison operations.
  - Added `SizeFilter` struct to hold size-based filter configuration.
  - Implemented the `SizeFilter::parse` method to parse the size filter string.
  - Implemented the `SizeFilter::to_bytes` method to convert the size filter value to bytes.
  - Implemented the `SizeFilter::matches` method to check if a file's size matches the filter.
  - Integrated size filter into the scanning process.
- **Tests**:
  - Added integration tests to verify size-based filtering.
  - Created test cases for various size filters such as smaller than 10 bytes, larger than 50KiB, exactly 1MiB, larger than 2MiB, and approximately 1KiB.

This enhancement improves the flexibility and functionality of `rfind`, allowing users to perform more specific searches based on file sizes.